### PR TITLE
removes some unused Point class values to reduce save data size

### DIFF
--- a/webapp/client/public/js/verlet.js
+++ b/webapp/client/public/js/verlet.js
@@ -51,9 +51,9 @@ function Point(current_x, current_y, materiality="material") {  // materiality c
   this.width = 0;
   this.materiality = materiality;
   this.fixed = false;
-  this.grabbed = false;
-  this.mxd = null;  // mouse x distance (upon grab)
-  this.myd = null;  // mouse y distance (upon grab)
+  // this.grabbed = false;
+  // this.mxd = null;  // mouse x distance (upon grab)
+  // this.myd = null;  // mouse y distance (upon grab)
   this.id = pointCount;
   pointCount += 1;
 }


### PR DESCRIPTION
This just omits three Point class properties that are no longer being used in the current game version. Should reduce some of the data bloat when saving to JSON. 