### PR TITLE
fixes mode save issues

### DIFF
--- a/webapp/client/public/js/index.js
+++ b/webapp/client/public/js/index.js
@@ -1070,9 +1070,9 @@ function runLogs( frequency ) {
 function display() {
   if ( gameHasBegun ) {
     if ( currentYear === 1 && currentSeason === "Spring" ) {  // starts with high frame rate for smooth seed scatter
-      renderBackground(); renderPlants(); displayEliminatePlantIconWithCursor();
+      renderBackground(); renderPlants();
     } else if ( worldTime % renderFactor === 0 ) {  // improves performance to render less often than verlet runs
-      renderBackground(); renderPlants(); displayEliminatePlantIconWithCursor();
+      renderBackground(); renderPlants();
     }
     trackSeasons();
     shedSunlight();
@@ -1082,6 +1082,7 @@ function display() {
   updateUI();
   runVerlet();
   if ( !ambientMode ) { 
+    displayEliminatePlantIconWithCursor();
     renderDemosInFirstYear();
     renderMilestones();
     renderHeightMarker(); 

--- a/webapp/client/public/js/index.js
+++ b/webapp/client/public/js/index.js
@@ -1070,9 +1070,9 @@ function runLogs( frequency ) {
 function display() {
   if ( gameHasBegun ) {
     if ( currentYear === 1 && currentSeason === "Spring" ) {  // starts with high frame rate for smooth seed scatter
-      renderBackground(); renderPlants();
+      renderBackground(); renderPlants(); displayEliminatePlantIconWithCursor();
     } else if ( worldTime % renderFactor === 0 ) {  // improves performance to render less often than verlet runs
-      renderBackground(); renderPlants();
+      renderBackground(); renderPlants(); displayEliminatePlantIconWithCursor();
     }
     trackSeasons();
     shedSunlight();
@@ -1082,7 +1082,6 @@ function display() {
   updateUI();
   runVerlet();
   if ( !ambientMode ) { 
-    displayEliminatePlantIconWithCursor();
     renderDemosInFirstYear();
     renderMilestones();
     renderHeightMarker(); 

--- a/webapp/client/public/js/save.js
+++ b/webapp/client/public/js/save.js
@@ -10,62 +10,62 @@
 /////**** Record Initial Raw Save Data ****/////
 
 
-var savedGameData = {};
+var localSavedGameData = {};
 
 
 
 function saveGame() {
 	//object collections
-	savedGameData.points = JSON.parse(JSON.stringify(points));
-	savedGameData.spans = JSON.parse(JSON.stringify(spans));
-	savedGameData.skins = JSON.parse(JSON.stringify(skins));
-	savedGameData.seeds = JSON.parse(JSON.stringify(seeds));
-	savedGameData.plants = JSON.parse(JSON.stringify(plants));
-	savedGameData.pollinationAnimations = [];
+	localSavedGameData.points = JSON.parse(JSON.stringify(points));
+	localSavedGameData.spans = JSON.parse(JSON.stringify(spans));
+	localSavedGameData.skins = JSON.parse(JSON.stringify(skins));
+	localSavedGameData.seeds = JSON.parse(JSON.stringify(seeds));
+	localSavedGameData.plants = JSON.parse(JSON.stringify(plants));
+	localSavedGameData.pollinationAnimations = [];
 	//counters
-	savedGameData.pointCount = pointCount;
-	savedGameData.spanCount = spanCount;
-	savedGameData.skinCount = skinCount;
-	savedGameData.seedCount = seedCount;
-	savedGameData.plantCount = plantCount;
-	savedGameData.pollinationAnimationCount = 0;
+	localSavedGameData.pointCount = pointCount;
+	localSavedGameData.spanCount = spanCount;
+	localSavedGameData.skinCount = skinCount;
+	localSavedGameData.seedCount = seedCount;
+	localSavedGameData.plantCount = plantCount;
+	localSavedGameData.pollinationAnimationCount = 0;
 	//settings
-	savedGameData.gameDifficulty = gameDifficulty;
-	savedGameData.ambientMode = ambientMode;
-	savedGameData.endOfGameAnnouncementDisplayed = endOfGameAnnouncementDisplayed;
+	localSavedGameData.gameDifficulty = gameDifficulty;
+	localSavedGameData.ambientMode = ambientMode;
+	localSavedGameData.endOfGameAnnouncementDisplayed = endOfGameAnnouncementDisplayed;
 	//progress
-	savedGameData.highestRedFlowerPct = highestRedFlowerPct;
-	savedGameData.heightMarker = heightMarker;
-	savedGameData.gameHasBegun = gameHasBegun;
-	savedGameData.readyForEliminationDemo = readyForEliminationDemo;
-	savedGameData.readyForChangeDemo = readyForChangeDemo;
-	savedGameData.eliminationDemoHasBegun = eliminationDemoHasBegun;
-	savedGameData.changeDemoHasBegun = changeDemoHasBegun;
-	savedGameData.allDemosHaveRun = allDemosHaveRun;
-	savedGameData.readyForNextMilestoneAnnouncement = readyForNextMilestoneAnnouncement;
-	savedGameData.milestoneFirstRedHasBeenRun = milestoneFirstRedHasBeenRun;
-	savedGameData.milestoneThirdHasBeenRun = milestoneThirdHasBeenRun;
-	savedGameData.milestoneHalfHasBeenRun = milestoneHalfHasBeenRun;
-	savedGameData.milestoneTwoThirdsHasBeenRun = milestoneTwoThirdsHasBeenRun;
-	savedGameData.milestone90HasBeenRun = milestone90HasBeenRun;
+	localSavedGameData.gameHasBegun = gameHasBegun;
+	localSavedGameData.highestRedFlowerPct = highestRedFlowerPct;
+	localSavedGameData.heightMarker = heightMarker;
+	localSavedGameData.readyForEliminationDemo = readyForEliminationDemo;
+	localSavedGameData.readyForChangeDemo = readyForChangeDemo;
+	localSavedGameData.eliminationDemoHasBegun = eliminationDemoHasBegun;
+	localSavedGameData.changeDemoHasBegun = changeDemoHasBegun;
+	localSavedGameData.allDemosHaveRun = allDemosHaveRun;
+	localSavedGameData.readyForNextMilestoneAnnouncement = readyForNextMilestoneAnnouncement;
+	localSavedGameData.milestoneFirstRedHasBeenRun = milestoneFirstRedHasBeenRun;
+	localSavedGameData.milestoneThirdHasBeenRun = milestoneThirdHasBeenRun;
+	localSavedGameData.milestoneHalfHasBeenRun = milestoneHalfHasBeenRun;
+	localSavedGameData.milestoneTwoThirdsHasBeenRun = milestoneTwoThirdsHasBeenRun;
+	localSavedGameData.milestone90HasBeenRun = milestone90HasBeenRun;
 	//time
-	savedGameData.worldTime = worldTime;
-	savedGameData.currentYear = currentYear;
-	savedGameData.yearTime = yearTime;
-	savedGameData.currentSeason = currentSeason;
-	savedGameData.suL = suL;
-	savedGameData.photosynthesisRatio = photosynthesisRatio;
-	savedGameData.livEnExp = livEnExp;
-	savedGameData.csbg = csbg;
-	savedGameData.psbg = psbg;
-	savedGameData.ccs1 = ccs1;
-	savedGameData.ccs2 = ccs2;
-	savedGameData.ccs3 = ccs3;
-	savedGameData.ccs4 = ccs4;
+	localSavedGameData.worldTime = worldTime;
+	localSavedGameData.currentYear = currentYear;
+	localSavedGameData.yearTime = yearTime;
+	localSavedGameData.currentSeason = currentSeason;
+	localSavedGameData.suL = suL;
+	localSavedGameData.photosynthesisRatio = photosynthesisRatio;
+	localSavedGameData.livEnExp = livEnExp;
+	localSavedGameData.csbg = csbg;
+	localSavedGameData.psbg = psbg;
+	localSavedGameData.ccs1 = ccs1;
+	localSavedGameData.ccs2 = ccs2;
+	localSavedGameData.ccs3 = ccs3;
+	localSavedGameData.ccs4 = ccs4;
 	//misc.
-	savedGameData.initialGeneValueAverages = initialGeneValueAverages;
+	localSavedGameData.initialGeneValueAverages = initialGeneValueAverages;
 	//encode & compress data
-  savedGameData = encodeAndCompressSavedGameData( savedGameData );
+  localSavedGameData = encodeAndCompressSavedGameData( localSavedGameData );
 }
 
 
@@ -284,14 +284,13 @@ function resumeSavedGame( retrievedGameData ) {
 	plantCount = parsedData.plantCount;
 	pollinationAnimationCount = 0;
 	//settings
-	gameDifficulty = parsedData.gameDifficulty;
 	ambientMode = parsedData.ambientMode;
+	gameDifficulty = parsedData.gameDifficulty;
 	endOfGameAnnouncementDisplayed = parsedData.endOfGameAnnouncementDisplayed;
-	viewShadows = parsedData.viewShadows;
 	//progress
 	highestRedFlowerPct = parsedData.highestRedFlowerPct;
-	heightMarker = parsedData.heightMarker;
 	$("#height_number").text( Math.floor( highestRedFlowerPct ) );
+	heightMarker = parsedData.heightMarker;
 	gameHasBegun = parsedData.gameHasBegun;
 	readyForEliminationDemo = parsedData.readyForEliminationDemo;
 	readyForChangeDemo = parsedData.readyForChangeDemo;
@@ -309,33 +308,34 @@ function resumeSavedGame( retrievedGameData ) {
 	currentYear = parsedData.currentYear;
 	yearTime = parsedData.yearTime;
 	currentSeason = parsedData.currentSeason;
-	suL = parsedData.suL;
+	suL = parsedData.suL;  // summer length (varies depending on average plant segment count)
 	photosynthesisRatio = parsedData.photosynthesisRatio;
 	livEnExp = parsedData.livEnExp;
-	csbg = parsedData.csbg;
-	psbg = parsedData.psbg;
-	ccs1 = parsedData.ccs1;
-	ccs2 = parsedData.ccs2;
-	ccs3 = parsedData.ccs3;
-	ccs4 = parsedData.ccs4;
+	csbg = parsedData.csbg;  // current season background
+	psbg = parsedData.psbg;  // previous season background
+	ccs1 = parsedData.ccs1;  // current color stop 1
+	ccs2 = parsedData.ccs2;  // current color stop 2
+	ccs3 = parsedData.ccs3;  // current color stop 3
+	ccs4 = parsedData.ccs4;  // current color stop 4
 	//misc.
 	initialGeneValueAverages = parsedData.initialGeneValueAverages;
 }
 
 
+function resumeState( game ) {
+	resumeSavedGame( game );
+	localSavedGameData = {};
+	$("#landing_page_div, #overlay_game_mode_options_div, #overlay_ambient_mode_options_div").hide();
+	$(".icon, #footer_div").show();
+	if ( ambientMode ) { displayAmbientModeUI(); } else { displayGameModeUI(); }
+	pause();
 
-
-/////**** Resume Saved Game ****/////
-
-function resumeState(game){
-	window.requestAnimationFrame(window.resume)
-	resumeSavedGame( game )
-	savedGameData = {}
-	button_game_mode.click()
-	$("#overlay_game_mode_options_div, #overlay_ambient_mode_options_div").fadeOut(500, function(){
-		$(".icon").fadeIn(5000);
-		$("#footer_div").fadeIn(5000);
-	});
-	gameHasBegun = true
-	window.requestAnimationFrame(window.pause)
+	renderBackground(); 
+	renderPlants();
+	
+	display();
 }
+
+
+
+

--- a/webapp/client/public/js/save.js
+++ b/webapp/client/public/js/save.js
@@ -300,7 +300,7 @@ function resumeSavedGame( retrievedGameData ) {
 	readyForNextMilestoneAnnouncement = parsedData.readyForNextMilestoneAnnouncement;
 	milestoneFirstRedHasBeenRun = parsedData.milestoneFirstRedHasBeenRun;
 	milestoneThirdHasBeenRun = parsedData.milestoneThirdHasBeenRun;
-	milestoneHalfHasBeenRun = parsedData.milestoneHalfHasBeenRu;
+	milestoneHalfHasBeenRun = parsedData.milestoneHalfHasBeenRun;
 	milestoneTwoThirdsHasBeenRun = parsedData.milestoneTwoThirdsHasBeenRun;
 	milestone90HasBeenRun = parsedData.milestone90HasBeenRun;
 	//time
@@ -329,10 +329,8 @@ function resumeState( game ) {
 	$(".icon, #footer_div").show();
 	if ( ambientMode ) { displayAmbientModeUI(); } else { displayGameModeUI(); }
 	pause();
-
 	renderBackground(); 
 	renderPlants();
-	
 	display();
 }
 

--- a/webapp/client/public/js/ui.js
+++ b/webapp/client/public/js/ui.js
@@ -285,9 +285,23 @@ function removeModals() {
   infoModalOpenWhilePaused = false;
 }
 
-function omitRedFlowerFooterContent() {
-  $("#height_text, #tag_div, #tag_svg, #tag_content, #percent").css("visibility", "hidden");
+
+///display game mode footer content
+function displayGameModeUI() {
+  viewRedFlowerIndicator = true;
+  $("#height_text, #tag_div, #tag_svg, #tag_content, #percent").css("visibility", "visible");
+  $("#season_left, #pie_svg_left").css("display", "inline");
+  $("#ambient_footer_right").css("display", "none");
 }
+
+///display ambient mode footer
+function displayAmbientModeUI() {
+  viewRedFlowerIndicator = false;
+  $("#height_text, #tag_div, #tag_svg, #tag_content, #percent").css("visibility", "hidden");
+  $("#season_left, #pie_svg_left").css("display", "none");
+  $("#ambient_footer_right").css("display", "block");
+}
+
 
 
 
@@ -423,6 +437,8 @@ $(window).resize(function() {
 $("#button_game_mode").click(function(){
   $("#landing_page_div").hide();
   $("#overlay_game_mode_options_div").css("visibility", "visible");
+  ambientMode = false;
+  displayGameModeUI();
 });
 
 ///choose ambient mode on landing
@@ -430,10 +446,7 @@ $("#button_ambient_mode").click(function(){
   $("#landing_page_div").hide();
   $("#overlay_ambient_mode_options_div").css("visibility", "visible");
   ambientMode = true;
-  viewRedFlowerIndicator = false;
-  omitRedFlowerFooterContent();
-  $("#season_left, #pie_svg_left").css("display", "none");
-  $("#ambient_footer_right").css("display", "block");
+  displayAmbientModeUI();
 });
 
 ///select beginner on game options overlay
@@ -596,13 +609,13 @@ $("#screenshot").click(function(){
 ///save icon (saves the game)
 $("#icon_save").click(function(){
   //(placeholder until database is set up...)
-  if ( Object.keys(savedGameData).length === 0 ) {
+  if ( Object.keys(localSavedGameData).length === 0 ) {
     if ( confirm("Save your progress here?") ) { 
       saveGame(); 
     } 
   } else {
-    if ( confirm("Resume where you last saved your progress?\n(This will delete your old save point ... for now. But you can save again after this.)") ) { resumeSavedGame( savedGameData ); 
-      savedGameData = {};  // removes previous saved game so new game can be saved
+    if ( confirm("Resume where you last saved your progress?\n(This will delete your old save point ... for now. But you can save again after this.)") ) { resumeSavedGame( localSavedGameData ); 
+      localSavedGameData = {};  // removes previous saved game so new game can be saved
     }
   }
 });

--- a/webapp/client/src/utils/save.js
+++ b/webapp/client/src/utils/save.js
@@ -28,7 +28,7 @@ export default {
       API.saveGame({
         username: app.username,
         _id: app._id,
-        saveObj: window.savedGameData
+        saveObj: window.localSavedGameData
       })
         .then( resp => {
           alert("game saved 👍")


### PR DESCRIPTION
This fixes a bug that caused resumed games not to display in the correct "game mode" or "ambient mode."

* updates `resumeState()` by hiding divs instead of hard coding game mode.

* adds [`displayAmbientModeUI()`](https://github.com/matthewmain/kiss_the_sky/compare/save-fix?expand=1#diff-ea4109f1ca56518a85e6b829915693d1R298) and [`displayGameModeUI()`](https://github.com/matthewmain/kiss_the_sky/compare/save-fix?expand=1#diff-ea4109f1ca56518a85e6b829915693d1R290) in ui.js to better handle modes, and [calls one or the other in `resumeState()`](https://github.com/matthewmain/kiss_the_sky/compare/save-fix?expand=1#diff-6ab5a57a6ffc36dd870d14a97aa0157dR330), depending on the saved game's mode.

* renders game screen once after pausing so that a preview of the resumed game will appear onscreen before unpausing to resume.

* **(HEADS-UP)** I also changed the `savedGameData` variable name to `localSavedGameData` throughout all app files for better clarity, now that we've got a bunch of saved data sets. I'm pretty sure I updated [`client/src/utils/save.js`](https://github.com/matthewmain/kiss_the_sky/compare/save-fix?expand=1#diff-ef723bea3841e921dbadb5b21c7335ddR31) correctly for this, but might want to double-check.

* **(HEADS-UP)** I was confused about what `window.requestAnimationFrame(window.pause)` was doing earlier--I thought it was some kind of built-in function that automatically paused the JS running in the browser I hadn't seen before. (I didn't know you could call a JS function on the window element like that.) After updating the code to handle resumed games, now I'm just [calling the simple `pause()` function](https://github.com/matthewmain/kiss_the_sky/compare/save-fix?expand=1#diff-6ab5a57a6ffc36dd870d14a97aa0157dR331), and seems to be working. But if your version was doing something behind the scenes in React that this will break, lmk and I'll put it back.
