### PR TITLE
changes so seeds can't germinate in the same spring they're pollinated

### DIFF
--- a/webapp/client/public/js/index.js
+++ b/webapp/client/public/js/index.js
@@ -352,7 +352,7 @@ function germinateSeedWhenReady( seed ) {
   if ( !seed.planted && p1Stable && p2Stable ) {
     plantSeed( seed );
   }
-  if ( seed.planted && currentSeason === "Spring" ) {
+  if ( seed.planted && currentSeason === "Spring" && seed.generation === currentYear ) {
     germinateSeed( seed );
   }
 }


### PR DESCRIPTION
This didn't happen very often but, when plants developed fast in spring, were pollinated, then killed and their seeds were then planted all in the same spring, those new seeds would germinate. This made it too hard to control plant growth while plants were growing up so quickly, especially when a large number of small plants were maturing at once. Now, this basically follows the model of seeds needing a cold winter before they can germinate, which forces just one generation of plants per year.