### PR TITLE
fixed safari flower and menu bug

### DIFF
--- a/webapp/client/src/components/Flower/flower.js
+++ b/webapp/client/src/components/Flower/flower.js
@@ -11,7 +11,9 @@ const Flower = (props) => {
         maxWidth: `${!props.hide ? props.size+"px" : "0px"}`,
         paddingRight: `${!props.hide ? "0px" : "12px"}`,
       }}
-      width={props.size+'px'} height={props.size+'px'} viewBox="0 0 43 49" version="1.1" xmlns="http://www.w3.org/2000/svg"
+      width={!props.hide ? props.size+"px" : "0px"}
+      height={!props.hide ? props.size+"px" : "0px"}
+      viewBox="0 0 43 49" version="1.1" xmlns="http://www.w3.org/2000/svg"
     >
       <g id="Symbols" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
         <g id="page-header-right" transform="translate(-41.000000, -1.000000)" fillRule="nonzero">

--- a/webapp/client/src/components/Menu/menu.js
+++ b/webapp/client/src/components/Menu/menu.js
@@ -48,10 +48,12 @@ class Landing extends Component {
   addClickToCloseEvent = ()=>{
     if (!document.body.hasOnClick) {
       document.body.hasOnClick = true
-      document.body.addEventListener("click", (event)=>{
+      document.body.addEventListener("click", (event) => {
+        const path = event.composedPath()
         if (
-          event.path.filter(e=>e.classList && e.classList.contains("noListen")).length === 0
-          && this.state.open
+          path.filter(e=>e.classList && e.classList.contains("noListen")).length === 0
+          &&
+          this.state.open
         ) {
           this.toggleMenu()
         }


### PR DESCRIPTION
For reference... if you ever use `event.path` on a DOM event listener, safari won't respect it.

So... use `event.composedPath()` 👍